### PR TITLE
Create ability to have controlled tabs instance :sparkles:

### DIFF
--- a/addon/components/core-tabs/component.js
+++ b/addon/components/core-tabs/component.js
@@ -83,6 +83,14 @@ export default Component.extend({
   // ---------------------------------------------------------------------------
 
   /**
+   * The elementId of the currently opened tab. This determines which tab is active and
+   * which tab's content to display. If this is empty, no tabs are open.
+   * @property activeId
+   * @type {String}
+   * @default ''
+   */
+  activeId: '',
+  /**
    * Pass false to use tab style without primary color tabs.
    * @property buttonStyle
    * @type {Boolean}
@@ -129,14 +137,6 @@ export default Component.extend({
   // Properties
   // ---------------------------------------------------------------------------
 
-  /**
-   * The elementId of the currently opened tab. This determines which tab is active and
-   * which tab's content to display. If this is empty, no tabs are open.
-   * @property activeId
-   * @type {String}
-   * @default ''
-   */
-  activeId: '',
   /**
    * Bound attributes:
    * - `data-test`: for precise testing identification

--- a/addon/components/core-tabs/content/component.js
+++ b/addon/components/core-tabs/content/component.js
@@ -3,7 +3,7 @@ import computed from 'ember-computed';
 import hbs from 'htmlbars-inline-precompile';
 
 /**
- * This component is yielded by the `core-tabs` component. The `_activeId` and
+ * This component is yielded by the `core-tabs` component. The `activeId` and
  * actions `registerTab` and `updateTab` are privately bound for internal use.
  *
  * On init each tab will register itself with the `core-tabs` wrapping container,
@@ -36,11 +36,11 @@ export default Component.extend({
   /**
    * The id of the currently active tab in the scope of the core-tabs component.
    * This is provided privately in the `core-tabs` yield hash.
-   * @property _activeId
+   * @property activeId
    * @type {String}
    * @default ''
    */
-  _activeId: '',
+  activeId: '',
   /**
    * Whether this tab should be hidden from view. Useful for situations where
    * a tab needs to exist in a particular place in the tab ordering but may
@@ -79,15 +79,15 @@ export default Component.extend({
   classNames: ['tabs-content'],
   /**
    * Computed `_hidden` accounts for whether the tab is selected (by checking
-   * `_activeId`) && if this tab has been flagged to be hidden with property
+   * `activeId`) && if this tab has been flagged to be hidden with property
    * `hidden`
    * @property _hidden
-   * @param {string} _activeId
+   * @param {string} activeId
    * @param {boolean} hidden
    * @returns {string} String of true/false for use with `aria-hidden` binding
    */
-  _hidden: computed('_activeId', 'hidden', function() {
-    if (this.get('hidden') || this.get('_activeId') !== this.get('elementId')) {
+  _hidden: computed('activeId', 'hidden', function() {
+    if (this.get('hidden') || this.get('activeId') !== this.get('elementId')) {
       return 'true';
     } else {
       return 'false';

--- a/app/styles/ember-radical/skeleton-theme/modules/_tabs.scss
+++ b/app/styles/ember-radical/skeleton-theme/modules/_tabs.scss
@@ -47,6 +47,7 @@
 
     .tab.active {
       background-color: #0e687a;
+      border-color: #0e687a;
       color : #fff;
     }
   }

--- a/app/styles/ember-radical/skeleton-theme/modules/_utility.scss
+++ b/app/styles/ember-radical/skeleton-theme/modules/_utility.scss
@@ -32,6 +32,13 @@ li[aria-hidden="false"] {
   pointer-events: auto;
   visibility: visible;
 }
+span[role="presentation"],
+div[role="presentation"],
+li[role="presentation"] {
+  display: initial;
+  pointer-events: auto;
+  visibility: visible;;
+}
 
 // Misc
 // -----------------------------------------------------------------------------

--- a/tests/integration/components/core-tabs/component-test.js
+++ b/tests/integration/components/core-tabs/component-test.js
@@ -178,3 +178,47 @@ test('it shows tabpanels when a tab label is clicked', function(assert) {
   assert.equal(this.$('[data-test="panel-b"]').attr('aria-hidden'), 'true', 'tabpanel B hidden');
   assert.equal(this.$('[data-test="panel-c"]').attr('aria-hidden'), 'false', 'tabpanel C shown');
 });
+
+test('it works as a controlled tabs instance by passing activeId and onChange closures', function(assert) {
+  function onChangeClosure({ elementId }) {
+    this.set('controlledId', elementId);
+  }
+
+  this.set('controlledId', 'tabA');
+  this.set('actions.onChange', onChangeClosure);
+
+  this.render(hbs`
+    {{#core-tabs
+      activeId=controlledId
+      defaultTab=controlledId
+      onChange=(action 'onChange')
+      as |components|}}
+      {{#components.content label='Tab A' tabDataTest='tab-a' data-test='panel-a' elementId='tabA'}}
+        <p>Tab A Content</p>
+      {{/components.content}}
+      {{#components.content label='Tab B' tabDataTest='tab-b' data-test='panel-b' elementId='tabB'}}
+        <p>Tab B Content</p>
+      {{/components.content}}
+      {{#components.content label='Tab C' tabDataTest='tab-c' data-test='panel-c' elementId='tabC'}}
+        <p>Tab C Content</p>
+      {{/components.content}}
+    {{/core-tabs}}
+  `);
+
+  assert.ok(this.$('[data-test="tab-a"]').hasClass('active'), 'tab is active by default');
+  assert.equal(this.$('[data-test="panel-a"]').attr('aria-hidden'), 'false', 'panel is shown by default');
+
+  // Simulate user click
+  // ---------------------------------------------------------------------------
+  this.$('[data-test="tab-c"]').trigger('click');
+
+  assert.ok(this.$('[data-test="tab-c"]').hasClass('active'), 'user click activates tab');
+  assert.equal(this.$('[data-test="panel-c"]').attr('aria-hidden'), 'false', 'user click shows panel');
+
+  // Simulate controlled change
+  // ---------------------------------------------------------------------------
+  this.set('controlledId', 'tabB');
+
+  assert.ok(this.$('[data-test="tab-b"]').hasClass('active'), 'user click activates tab');
+  assert.equal(this.$('[data-test="panel-b"]').attr('aria-hidden'), 'false', 'user click shows panel');
+});


### PR DESCRIPTION
Adds the ability to programmatically open tabs within your application while still respecting user clicks by checking for closure `onChange` and calling with the clicked tab id.

Also sneaks in a style rule that allows the use of `aria-hidden` on an element that should still be visible in the dom by checking for `role='presentation'`. This allows for A++ accessibility.