### PR TITLE
🔨 Updates core-state public API to be easier to remember and use

### DIFF
--- a/addon/components/core-drawer/component.js
+++ b/addon/components/core-drawer/component.js
@@ -9,22 +9,24 @@ import {controls} from '../../utils/arias';
  * `content` subcomponents, which represent the title/trigger text to open the
  * drawer and the content to be revealed within the drawer, respectively.
  *
- * ### Usage
+ * ## Usage
  *
  * There are two ways to use `core-drawer`'s subcomponents:
  *
- * #### 1. Simple invocation via attrs
+ * ### 1. Simple invocation via attrs
  *
  * If you only have simple text (or pre-determined text/HTML within a variable)
  * to yield, you can simply use the `Target` and `Content` attrs on `core-drawer` to auto-invoke the subcomponents, like so:
  *
  * ```glimmer
- * {{core-drawer Target='Click to read more about puppies' Content='Imagine five paragraphs about puppies instead of this one sentence.'}}
+ * {{core-drawer
+ *   Target='Click to read more about puppies'
+ *   Content='Imagine five paragraphs about puppies instead of this one sentence.'}}
  * ```
  *
  * This is the easiest and quickest way to create an instance of `core-drawer`.
  *
- * #### 2. Full invocation via contextual components
+ * ### 2. Full invocation via contextual components
  *
  * If you have more complex needs in terms of the text/html/template code
  * that needs to exist in either the `target` or `content` subcomponents,
@@ -64,13 +66,15 @@ import {controls} from '../../utils/arias';
  * {{core-drawer Target='Hello' Content='I am open now' externalToggle=someProp}}
  * ```
  *
- * {{#core-state as |open close active toggle|}}
- *   {{#core-button click=(action toggle)}}Toggle Drawer{{/core-button}}
- *   {{core-drawer Target='Hello' Content='I am open now' externalToggle=active}}
+ * {{#core-state as |state stateActions|}}
+ *   {{#core-button click=(action stateActions.toggleState)}}Toggle Drawer{{/core-button}}
+ *   {{core-drawer Target='Hello' Content='I am open now' externalToggle=state}}
  * {{/core-state}}
  *
  * `core-drawer` will still continue to function normally with this property
  * passed in, but it gives you the ability to control it externally.
+ *
+ * ## Properties
  *
  * Configuration | Type | Default | Description
  * --- | --- | --- | ---
@@ -78,7 +82,7 @@ import {controls} from '../../utils/arias';
  * `icon` | string/boolean | 'arrow-down2' | Specifies which SVG icon to show in the `target`. Hides the icon if set to `false`
  * `buttonStyle` | boolean | false | Whether to style the `target` to look like a button
  *
- * ### A++ Accessibility
+ * ## A++ Accessibility Features
  *
  * - Drawer target auto-binds `aria-controls` to the value of the component ID
  * - Drawer target auto-binds `aria-expanded` to the expanded/collapsed state

--- a/addon/components/core-dropdown/component.js
+++ b/addon/components/core-dropdown/component.js
@@ -1,7 +1,6 @@
 import Component from 'ember-component';
 import computed from 'ember-computed';
 import hbs from 'htmlbars-inline-precompile';
-const devAssets = {};
 
 import { bindOnEscape, unbindOnEscape } from '../../utils/listeners';
 import { labelledby, describedby } from '../../utils/arias';
@@ -12,15 +11,15 @@ import { labelledby, describedby } from '../../utils/arias';
  * Welcome friend, if you're looking for a button/link that opens a dropdown
  * you've come to the right place.
  *
- * ### Usage
+ * ## Usage
  *
- * 1. Simple invocation. It's so easy. Just pass a Target and Content prop
+ * ### 1. Simple invocation. It's so easy. Just pass a Target and Content prop
  * and you've got a totally rad dropdown.
- * ```handlebars
+ * ```glimmer
  * {{core-dropdown Target="Open me!" Content="Hey, what's up?"}}
  * ```
  *
- * 2. Simple target with custom content. Use the Content contextual
+ * ### 2. Simple target with custom content. Use the Content contextual
  * component to add custom content to the dropdown.
  * ```handlebars
  * {{#core-dropdown Target="Open me!" as |components|}}
@@ -28,21 +27,22 @@ import { labelledby, describedby } from '../../utils/arias';
  * {{/core-dropdown}}
  * ```
  *
- * 3. Customize both the dropdown target and content.
- * ```handlebars
+ * ### 3. Customize both the dropdown target and content.
+ * ```glimmer
  * {{#core-dropdown as |components|}}
  *   {{#components.target}}Open me!{{/components.target}}
  *   {{#components.content}}Hey, what's up?{{/components.content}}
  * {{/core-dropdown}}
  * ```
  *
- * 4. Turn the target into a button with `buttonStyle=true` and pass a `brand`
- * to change the color button.
+ * ### 4. Turn the target into a button with `buttonStyle=true` and pass a
+ * `brand` to change the color button.
  * ```handlebars
  * {{core-dropdown buttonStyle=true brand="primary" Target="Open me!" Content="Hey, what's up?"}}
  * ```
+ *
  * Configuration | Type | Default | Description
- * --- | --- | ---
+ * --- | --- | --- | ---
  * `buttonStyle` | boolean | false | Whether to style the `target` to look like a button
  * `brand` | string | '' | The brand class to use to style the `target`
  *

--- a/addon/components/core-state/component.js
+++ b/addon/components/core-state/component.js
@@ -4,13 +4,40 @@ import hbs from 'htmlbars-inline-precompile';
 /**
  * Component that can be used for tracking state changes with modals or drawers.
  * Wrap either in one of these and use the yielded state and actions to handle
- * showing/hiding your component.
+ * showing/hiding/controlling your component.
  *
  * Useful mainly for demonstration/documentation purposes, but also handy for
  * when you don't have a convenient place to store state (particularly during
- * early development stages).
+ * early development stages). It's also kind of nice for not cluttering up your
+ * parent scope with a bunch of extra state and actions you might not want to
+ * hang onto. Go nuts!
  *
- * Try not to use this for real-real in prod tho, ok?
+ * ## Usage
+ *
+ * Instances of `core-state` yield an `active` property and a hash of `actions`
+ * for manipulating that state: `open`, `close`, and `toggleState`.
+ *
+ * ```handlebars
+ * {{#core-state as |state stateActions|}}
+ *   {{bank-vault
+ *     isOpen=state
+ *     closeVault=stateActions.close
+ *     openVault=stateActions.open}}
+ * {{/core-state}}
+ * ```
+ *
+ * Or for a smipler toggling implementation:
+ *
+ * ```handlebars
+ * {{#core-state as |switchState switchActions|}}
+ *   {{light-switch isOn=switchState toggleSwitch=switchActions.toggleState}}
+ * {{/core-state}}
+ * ```
+ *
+ * The actions in the actions hash have already been yielded via the action
+ * helper, so it is not necessary to continue using that helper when passing
+ * actions into child components as properties (but you totally still can if
+ * you would prefer to.
  *
  * @class Component.CoreState
  * @constructor
@@ -63,5 +90,9 @@ export default Component.extend({
 
   // Layout
   // ---------------------------------------------------------------------------
-  layout: hbs`{{yield (action 'open') (action 'close') active (action 'toggleState')}}`
+  layout: hbs`{{yield active (hash
+    open=(action 'open')
+    close=(action 'close')
+    toggleState=(action 'toggleState')
+  )}}`
 });

--- a/tests/dummy/app/templates/modals.hbs
+++ b/tests/dummy/app/templates/modals.hbs
@@ -1,14 +1,14 @@
 <div class="row">
   <div class="col-xs-8">
     <h1>Modals</h1>
-    {{#core-state as |open close active toggle|}}
+    {{#core-state as |state stateActions|}}
       {{#core-button
-        click=(action open)
+        click=(action stateActions.open)
         brand='primary'}}Open The Modal!{{/core-button}}
       {{#core-modal
-        open=active
+        open=state
         Header='This is a totally rad modal right here!'
-        closeModal=(action close)}}
+        closeModal=(action stateActions.close)}}
         <img src="https://media.giphy.com/media/l2R077quXSVyuV4bK/giphy.gif" alt="" style="width: 100%;" />
       {{/core-modal}}
     {{/core-state}}
@@ -22,13 +22,13 @@
 <div class="row">
   <div class="col-xs-8">
     <h5><code>Branded Header</code></h5>
-    {{#core-state as |open close active toggle|}}
+    {{#core-state as |state stateActions|}}
       {{#core-button
-        click=(action open)
+        click=(action stateActions.open)
         brand='primary'}}Open this branded modal{{/core-button}}
       {{#core-modal
-        open=active
-        closeModal=(action close) as |components|}}
+        open=state
+        closeModal=(action stateActions.close) as |components|}}
         {{#components.header brand='primary'}}<h3>YAS YAS YAS YAS</h3>{{/components.header}}
         <img src="https://media.giphy.com/media/kGZ4jJguXT5C0/giphy.gif" alt="" style="width: 100%;" />
       {{/core-modal}}
@@ -43,13 +43,13 @@
 <div class="row">
   <div class="col-xs-8">
     <h5><code>No Header (Still Accessible)</code></h5>
-    {{#core-state as |open close active toggle|}}
+    {{#core-state as |state stateActions|}}
       {{#core-button
-        click=(action open)}}Open this modal with no header{{/core-button}}
+        click=(action stateActions.open)}}Open this modal with no header{{/core-button}}
       {{#core-modal
-        open=active
+        open=state
         ariaHeader='This modal shows what a modal with no header looks like'
-        closeModal=(action close)}}
+        closeModal=(action stateActions.close)}}
         <p>Inspect the HTML of this sucker to see the screen-reader friendly
           header in action.</p>
         <img src="https://media.giphy.com/media/RDG5Q86EJiNTG/giphy.gif" alt="" style="width: 100%;" />

--- a/tests/integration/components/core-state/component-test.js
+++ b/tests/integration/components/core-state/component-test.js
@@ -6,18 +6,18 @@ moduleForComponent('core-state', 'Integration | Component | core state', {
 });
 
 test('it renders', function(assert) {
-  this.render(hbs`{{#core-state as |open close active toggleState|}}{{/core-state}}`);
+  this.render(hbs`{{#core-state as |state stateActions|}}{{/core-state}}`);
 
   assert.equal(this.$().text().trim(), '', 'Component renders block form correctly');
 });
 
 test('it can be used as a state tracker', function(assert) {
   this.render(hbs`
-    {{#core-state as |open close active toggleState|}}
-      {{#core-button click=(action open) id="open"}}Open{{/core-button}}
-      {{#core-button click=(action close) id="close"}}Close{{/core-button}}
+    {{#core-state as |state stateActions|}}
+      {{#core-button click=(action stateActions.open) id="open"}}Open{{/core-button}}
+      {{#core-button click=(action stateActions.close) id="close"}}Close{{/core-button}}
 
-      <div aria-hidden={{if active 'false' 'true'}} id="secrets">SECRET CONTENT</div>
+      <div aria-hidden={{if state 'false' 'true'}} id="secrets">SECRET CONTENT</div>
     {{/core-state}}
   `);
 
@@ -34,9 +34,9 @@ test('it can be used as a state tracker', function(assert) {
 
 test('it can be used as a state toggler', function(assert) {
   this.render(hbs`
-    {{#core-state as |open close active toggleState|}}
-      {{#core-button click=(action toggleState) id="toggle"}}Toggle{{/core-button}}
-      <div aria-hidden={{if active 'false' 'true'}} id="secrets">SECRET CONTENT</div>
+    {{#core-state as |state stateActions|}}
+      {{#core-button click=(action stateActions.toggleState) id="toggle"}}Toggle{{/core-button}}
+      <div aria-hidden={{if state 'false' 'true'}} id="secrets">SECRET CONTENT</div>
     {{/core-state}}
   `);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1552,7 +1552,7 @@ ember-cli-get-dependency-depth@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-get-dependency-depth/-/ember-cli-get-dependency-depth-1.0.0.tgz#e0afecf82a2d52f00f28ab468295281aec368d11"
 
-ember-cli-htmlbars-inline-precompile@^0.3.1, ember-cli-htmlbars-inline-precompile@^0.3.3:
+ember-cli-htmlbars-inline-precompile@^0.3.3:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-0.3.6.tgz#4095fe423f93102724c0725e4dd1a31f25e24de5"
   dependencies:
@@ -1561,7 +1561,7 @@ ember-cli-htmlbars-inline-precompile@^0.3.1, ember-cli-htmlbars-inline-precompil
     ember-cli-htmlbars "^1.0.0"
     hash-for-dep "^1.0.2"
 
-ember-cli-htmlbars@^1.0.0, ember-cli-htmlbars@^1.0.10, ember-cli-htmlbars@^1.0.3:
+ember-cli-htmlbars@^1.0.0, ember-cli-htmlbars@^1.0.10:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-1.1.1.tgz#8776cf59796dac8f32e8625fc6d1ea45ffa55de1"
   dependencies:
@@ -1831,14 +1831,13 @@ ember-export-application-global@^1.0.5:
   dependencies:
     ember-cli-babel "^5.1.10"
 
-ember-fountainhead@beta:
-  version "2.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/ember-fountainhead/-/ember-fountainhead-2.0.0-beta.1.tgz#8a159f036a1193c7e6e71debdb539a82c2c24557"
+ember-fountainhead@2.0.0-beta.8:
+  version "2.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/ember-fountainhead/-/ember-fountainhead-2.0.0-beta.8.tgz#eef7f582a7cc6549479b7b40b74e5026c324b09f"
   dependencies:
-    ember-cli-babel "^5.1.6"
-    ember-cli-htmlbars "^1.0.3"
-    ember-cli-htmlbars-inline-precompile "^0.3.1"
-    ember-radical "git://github.com/healthsparq/ember-radical.git#7bffd41445e6cac3b658be8aa10cb1a271c5731a"
+    ember-cli-babel "^5.1.7"
+    ember-cli-htmlbars "^1.0.10"
+    ember-cli-htmlbars-inline-precompile "^0.3.3"
     markdown-it "^8.0.0"
     prismjs "^1.5.1"
     yuidocjs "^0.10.2"
@@ -1858,14 +1857,6 @@ ember-qunit@^1.0.0-beta.1:
   resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-1.0.0.tgz#7db7b9f0c4e1f331ae1a3fd8c0688778d5dea7fb"
   dependencies:
     ember-test-helpers "^0.5.32"
-
-"ember-radical@git://github.com/healthsparq/ember-radical.git#7bffd41445e6cac3b658be8aa10cb1a271c5731a":
-  version "0.2.0"
-  resolved "git://github.com/healthsparq/ember-radical.git#7bffd41445e6cac3b658be8aa10cb1a271c5731a"
-  dependencies:
-    ember-cli-babel "^5.1.7"
-    ember-cli-htmlbars "^1.0.10"
-    ember-cli-htmlbars-inline-precompile "^0.3.3"
 
 ember-resolver@^2.0.3:
   version "2.1.0"


### PR DESCRIPTION
## Description

This pull request changes the public API for working with the `core-state` component. Up until now, the component has yielded a state property and three actions for manipulating that property, in an order that is difficult to remember.

This update yields the state property first and a hash of the state manipulating actions second.

These are the changes included:

- 🔨 Updated `core-state`'s public API
- 🔨📝 Updated instances of `core-state` used in the dummy app and in docs to use the new API
- ✅ Updated `core-state` tests to use the new API

## Tests
- [x] I added tests for changes I made
- [x] All tests are _definitely_ passing