### PR TITLE
Clean up feature flag file after import so we don't have to ignore it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,3 @@
 /libpeerconnection.log
 npm-debug.log*
 testem.log
-vendor/feature-flags.js

--- a/blueprints/ember-radical/index.js
+++ b/blueprints/ember-radical/index.js
@@ -1,7 +1,4 @@
 'use strict';
-const fs = require('fs');
-const path = require('path');
-const EOL = require('os').EOL;
 
 module.exports = {
   normalizeEntityName: function() {
@@ -10,19 +7,26 @@ module.exports = {
     // to us
   },
 
-  // Add an ignore for generated vendor feature flags
+  /*
+   * At one point we added feature flags to the vendor dir and left them there,
+   * so we manually updated the gitignore for consumers. Instead we know delete
+   * those feature flags after importing them. If we get down the road and this
+   * method is working great, delete the gitignore changes below.
+   */
   afterInstall() {
     // Read current gitignore
-    let gitignore = fs.readFileSync(path.resolve('.gitignore'), { encoding: 'utf8' });
+    // let gitignore = fs.readFileSync(path.resolve('.gitignore'), { encoding: 'utf8' });
 
     // If feature-flags has already been added, do less
-    if (gitignore.indexOf('vendor/feature-flags.js') !== -1) { return; }
+    // if (gitignore.indexOf('vendor/feature-flags.js') !== -1) { return; }
 
     // Write new entry to gitignore
-    fs.writeFileSync(
-      path.resolve('.gitignore'),
-      `${gitignore}${EOL}# Auto generated ember-radical feature flags${EOL}vendor/feature-flags.js`,
-      { encoding: 'utf8' }
-    );
+    // fs.writeFileSync(
+    //   path.resolve('.gitignore'),
+    //   `${gitignore}${EOL}# Auto generated ember-radical feature flags${EOL}vendor/feature-flags.js`,
+    //   { encoding: 'utf8' }
+    // );
+
+    console.log('Thanks for installing Ember Radical, we hope you build something radical!');
   }
 };

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports = {
    * Create file with consuming applications feature flags in `/vendor` and call
    * `app.import` on that file. This creates the necessary globals for feature
    * flags in dev and test envs, or always if `stripCode` has been turned off.
+   * After importing those flags delete the file for maximum 🔮.
    */
   _importFeatureFlags(flags) {
     try {
@@ -42,6 +43,12 @@ module.exports = {
     }
 
     this.app.import(`${this.vendorPath}/feature-flags.js`);
+
+    try {
+      fs.unlinkSync(path.resolve('vendor', 'feature-flags.js'));
+    } catch(ex) {
+      console.warn('error deleting feature flags: ', ex);
+    }
   },
 
   // Addon Hooks


### PR DESCRIPTION
## Description
<!-- Explanation about your PR, summarize what changes you've made. -->
<!-- If an issue exists for your issue, PLEASE reference it here! -->

After importing feature flags into a consuming application, delete the generated feature flag file. This makes our consumption a little cleaner because we don't have to update consuming apps to ignore that file.

These are the changes included:

- :sparkles: Delete auto-generated feature flag file after import

## Tests
<!-- Don't lie about this, Travis CI will call you out pretty fast if you do -->
- [x] All tests are _definitely_ passing
