### PR TITLE
🐛 #37 Removes references to theme variables from structural styles

### DIFF
--- a/app/styles/ember-radical/component-structures/_alerts.scss
+++ b/app/styles/ember-radical/component-structures/_alerts.scss
@@ -4,7 +4,6 @@
 
 .core-alert {
   position: relative;
-  padding: $alert-padding;
   margin-bottom: 1rem;
 
   > p,
@@ -14,11 +13,9 @@
 }
 
 .alert-dismissible {
-  padding-right: ($alert-padding + 1.5);
-
   .close {
     position: absolute;
-    top: $alert-padding;
-    right: $alert-padding;
+    top: 0; // this gets overridden by the skeleton-theme
+    right: 0; // this gets overridden by the skeleton-theme
   }
 }

--- a/app/styles/ember-radical/component-structures/_tooltips.scss
+++ b/app/styles/ember-radical/component-structures/_tooltips.scss
@@ -59,11 +59,4 @@
       transform: rotate(45deg);
     }
   }
-
-  // If you need an svg in a tooltip, they need to be 1x instead of 1.2 b/c
-  // tooltip font size is a lot smaller
-  .core-svg {
-    height: $rem-root * 1px !important;
-    width: $rem-root * 1px !important;
-  }
 }

--- a/app/styles/ember-radical/skeleton-theme/modules/_alerts.scss
+++ b/app/styles/ember-radical/skeleton-theme/modules/_alerts.scss
@@ -6,11 +6,15 @@
   border-width: 1px;
   border-radius: $alert-border-radius;
   border-style: solid;
+  padding: $alert-padding;
 }
 
 .alert-dismissible {
+  padding-right: ($alert-padding + 1.5);
   .close {
     color: inherit;
+    top: $alert-padding;
+    right: $alert-padding;
   }
 }
 

--- a/app/styles/ember-radical/skeleton-theme/modules/_tooltips.scss
+++ b/app/styles/ember-radical/skeleton-theme/modules/_tooltips.scss
@@ -17,4 +17,11 @@
       box-shadow: -1px -1px 6px rgba(0, 0, 0, 0.15);
     }
   }
+
+  // If you need an svg in a tooltip, they need to be 1x instead of 1.2 b/c
+  // tooltip font size is a lot smaller
+  .core-svg {
+    height: $rem-root * 1px !important;
+    width: $rem-root * 1px !important;
+  }
 }


### PR DESCRIPTION
## Description
This PR addresses #37 by removing any references within the _structural styles_ to variables from the _theme styles_, to ensure that users who opt not to use the theme are still able to compile/utilize the structural CSS.

These are the changes included:

- 🐛 Fixed a CSS bug (variable references could be broken if theme styles were removed from build)

## Tests
N/A
