### PR TITLE
🐛 #42 core-dropdowns will now properly close on background click

### DIFF
--- a/app/styles/ember-radical/component-structures/_dropdowns.scss
+++ b/app/styles/ember-radical/component-structures/_dropdowns.scss
@@ -15,6 +15,12 @@
   right: 0;
   bottom: 0;
   left: 0;
+
+  // Trick Ember into firing action handlers for touch/tap events on
+  // mobile/touch devices. This width should cover smartphones and most tablets.
+  @media only screen and (max-width: 64.063em) {
+    cursor: pointer;
+  }
 }
 
 .dropdown-content {


### PR DESCRIPTION
## Description
Addresses #42;
On touch-screen devices, non-interactive HTML elements (like DIVs) don't fire events on touch/tap that will trigger Ember action handlers that are based on events like clicks. This can be remedied by using `cursor: pointer;` to style a non-interactive element and essentially "coerce" it into  being interactive. This is necessary to allow clicks on the transparent background scrim that is placed behind the dropdown elements to trigger closing of the dropdown.

These are the changes included:

- :bug: Adds a style rule for the core-dropdown-background class to make it "click"/"tap"-able

## Tests
No test updates/changes are necessary (although perhaps we should write one for this use case)