### PR TITLE
Close styles cleanup

### DIFF
--- a/addon/components/rad-alert/component.js
+++ b/addon/components/rad-alert/component.js
@@ -11,7 +11,7 @@ import hbs from 'htmlbars-inline-precompile';
  * #### 1. Basic usage
  * Alerts accept a `brand` property to change the alert color.
  *
- * ```handlebars
+ * ```glimmer
  * {{#rad-alert brand="primary"}}Even hunks were boys once. Pretty little boy hunks!{{/rad-alert}}
  * {{#rad-alert brand="secondary"}}If you’re raking the leaves and it gets all over your driveway, just hose it off dummy.{{/rad-alert}}
  * {{#rad-alert brand="success"}}You have smelly body parts? Smelly under your arms? In the armpits? Just… just put some vinegar on it! Why didn’t you think of that?{{/rad-alert}}
@@ -19,27 +19,18 @@ import hbs from 'htmlbars-inline-precompile';
  * {{#rad-alert brand="warning"}}Life comes from eggs. Not just for omelettes, ya dingus, you could make a baby boy or a baby girl too.{{/rad-alert}}
  * {{#rad-alert brand="danger"}}Go to bed early you doofus, ‘cause when you’re sleeping there’s no lonely times, just dreams.{{/rad-alert}}
  * ```
- *
- * {{#rad-alert brand="primary"}}Even hunks were boys once. Pretty little boy hunks!{{/rad-alert}}
- * {{#rad-alert brand="secondary"}}If you’re raking the leaves and it gets all over your driveway, just hose it off dummy.{{/rad-alert}}
- * {{#rad-alert brand="success"}}You have smelly body parts? Smelly under your arms? In the armpits? Just… just put some vinegar on it! Why didn’t you think of that?{{/rad-alert}}
- * {{#rad-alert brand="info"}}I’ll be brack.{{/rad-alert}}
- * {{#rad-alert brand="warning"}}Life comes from eggs. Not just for omelettes, ya dingus, you could make a baby boy or a baby girl too.{{/rad-alert}}
- * {{#rad-alert brand="danger"}}Go to bed early you doofus, ‘cause when you’re sleeping there’s no lonely times, just dreams.{{/rad-alert}}
  *
  * #### 2. Dismissing
  * By default alerts are dismissible. You can disable this by passing a
  * `canDismiss` property.
  *
- * ```handlebars
+ * ```glimmer
  * {{#rad-alert brand="primary" canDismiss=false}}Try to dismiss this, ya dingus.{{/rad-alert}}
  * ```
  *
- * {{#rad-alert brand="primary" canDismiss=false}}Try to dismiss this, ya dingus.{{/rad-alert}}
- *
  * When alerts are dismissed they also fire an `onDismiss` action.
  *
- * ```handlebars
+ * ```glimmer
  * {{#rad-alert brand="primary" onDismiss=(action "handleDismiss")}}Dismiss me!{{/rad-alert}}
  * ```
  *

--- a/addon/components/rad-modal/component.js
+++ b/addon/components/rad-modal/component.js
@@ -424,7 +424,8 @@ export default Component.extend(devAssets, {
                 click=(action closeModal)
                 tagcategory=tagClose.category
                 tagaction=tagClose.action
-                taglabel=tagClose.label}}
+                taglabel=tagClose.label
+                data-test='rad-modal-close-button'}}
                 {{rad-svg svgId='x'}}
               {{/rad-button}}
             </div>

--- a/addon/components/rad-modal/component.js
+++ b/addon/components/rad-modal/component.js
@@ -420,7 +420,7 @@ export default Component.extend(devAssets, {
               {{#rad-button
                 link=true
                 aria-label='close'
-                classNames='close-x'
+                classNames='close'
                 click=(action closeModal)
                 tagcategory=tagClose.category
                 tagaction=tagClose.action

--- a/app/styles/ember-radical/_skeleton-theme.scss
+++ b/app/styles/ember-radical/_skeleton-theme.scss
@@ -45,6 +45,7 @@
 @import 'skeleton-theme/modules/tables';
 @import 'skeleton-theme/modules/forms';
 @import 'skeleton-theme/modules/utility';
+@import 'skeleton-theme/modules/close';
 
 // Components
 @import 'skeleton-theme/modules/alerts';

--- a/app/styles/ember-radical/component-structures/_alerts.scss
+++ b/app/styles/ember-radical/component-structures/_alerts.scss
@@ -15,7 +15,5 @@
 .alert-dismissible {
   .close {
     position: absolute;
-    top: 0; // this gets overridden by the skeleton-theme
-    right: 0; // this gets overridden by the skeleton-theme
   }
 }

--- a/app/styles/ember-radical/component-structures/_modal.scss
+++ b/app/styles/ember-radical/component-structures/_modal.scss
@@ -177,32 +177,6 @@
     width: 0;
     overflow: hidden;
   }
-
-  // X icon container, limit size and set to top right of header
-  .close-x {
-    height: 17px;
-    width: 17px;
-
-    position: absolute;
-    top: 20px;
-    right: 20px;
-
-    color: #666;
-
-    cursor: pointer;
-    opacity: 0.5;
-
-    &:hover {
-      color: #666;
-      opacity: 1;
-    }
-
-    // Adjust X location for change in modal padding when small
-    @media only screen and (min-width: 64.063em) {
-      top: 25px;
-      right: 30px;
-    }
-  }
 }
 
 // Modal Header

--- a/app/styles/ember-radical/skeleton-theme/modules/_alerts.scss
+++ b/app/styles/ember-radical/skeleton-theme/modules/_alerts.scss
@@ -12,7 +12,7 @@
 .alert-dismissible {
   padding-right: ($alert-padding + 1.5);
   .close {
-    color: inherit;
+    color: inherit !important;
     top: $alert-padding;
     right: $alert-padding;
   }

--- a/app/styles/ember-radical/skeleton-theme/modules/_close.scss
+++ b/app/styles/ember-radical/skeleton-theme/modules/_close.scss
@@ -1,0 +1,18 @@
+// ========================================================
+// Close Button Styles
+// ========================================================
+
+button.close {
+  float: right;
+  color: $close-color;
+
+  cursor: pointer;
+  opacity: 0.5;
+
+  &:hover,
+  &:focus {
+    color: $close-color;
+    opacity: 1;
+    text-decoration: none;
+  }
+}

--- a/app/styles/ember-radical/skeleton-theme/utils/_variables.scss
+++ b/app/styles/ember-radical/skeleton-theme/utils/_variables.scss
@@ -138,6 +138,10 @@ $btn-link-disabled-color: $gray-light;
 $btn-block-spacing-y: 0.5rem;
 $btn-toolbar-margin:  0.5rem;
 
+// Close Button
+// ---------------------------------------------------------------------------
+$close-color: #666;
+
 // Code
 // ---------------------------------------------------------------------------
 $code-padding-y: 0.2rem;

--- a/tests/integration/components/rad-modal/component-test.js
+++ b/tests/integration/components/rad-modal/component-test.js
@@ -198,7 +198,7 @@ test('it passes and binds closeModal action to background and header (aria heade
     assert.equal(this.$('[data-test="rad-modal-wrapper"]').attr('aria-hidden'), 'false', 'modal wrapper returns to visible');
 
     // Click close button
-    this.$('button.close-x').click();
+    this.$('[data-test="rad-modal-close-button"]').click();
 
     // Wait for updates
     return wait().then(() => {


### PR DESCRIPTION
<!-- Please use this helpful template for filing Pull Requests. -->
<!-- If you haven't read the contribution guide, please do before submitting a PR; it will likely save a lot of time during the review process. -->

## Description
Cleanup close styles for the modal and alert components and make them share the same class. Also added a variable for the color of the close button.

This pull request addresses Issue #29 .

These are the changes included:

- 💄 Cleanup close styles
- 📝  Update alert docs 

