### PR TITLE
Update dropdowns for bootstrap

### DIFF
--- a/addon/components/rad-dropdown/component.js
+++ b/addon/components/rad-dropdown/component.js
@@ -214,7 +214,7 @@ export default Component.extend({
 
     {{#if Target}}
       {{#rad-dropdown/target
-        aria-describedby=describedby
+        id=labelledby
         brand=brand
         click=(action (if hidden 'show' 'hide'))
         link=(not buttonStyle)
@@ -224,23 +224,25 @@ export default Component.extend({
     {{/if}}
 
     {{#if Content}}
-      {{#rad-dropdown/content hidden=hidden}}
+      {{#rad-dropdown/content
+        aria-labelledby=labelledby
+        hidden=hidden}}
         {{{Content}}}
       {{/rad-dropdown/content}}
     {{/if}}
 
     {{yield (hash
       target=(component 'rad-dropdown/target'
-        aria-describedby=describedby
+        id=labelledby
         brand=brand
         click=(action (if hidden 'show' 'hide'))
         link=(not buttonStyle)
         hidden=hidden)
       content=(component 'rad-dropdown/content'
+        aria-labelledby=labelledby
         dropdownMenu=dropdownMenu
         hidden=hidden)
       menu-item=(component 'rad-dropdown/menu-item'
-        aria-describedby=aria-describedby
         hide=(action 'hide'))
     ) (action 'show') (action 'hide') hidden aria-describedby aria-labelledby}}
   `

--- a/addon/components/rad-dropdown/component.js
+++ b/addon/components/rad-dropdown/component.js
@@ -41,6 +41,20 @@ import { labelledby, describedby } from '../../utils/arias';
  * {{rad-dropdown buttonStyle=true brand="primary" Target="Open me!" Content="Hey, what's up?"}}
  * ```
  *
+ * ### 5. Use as a dropdown menu with menu items
+ *
+ * ```glimmer
+ * {{#rad-dropdown dropdownMenu=true brand="primary" buttonStyle=true as |components|}}
+ *   {{#components.target}}
+ *     Open me! {{rad-svg svgId="arrow-down"}}
+ *   {{/components.target}}
+ *   {{#components.content}}
+ *     {{#components.menu-item}}Option 1{{/components.menu-item}}
+ *     {{#components.menu-item}}Option 2{{/components.menu-item}}
+ *   {{/components.content}}
+ * {{/rad-dropdown}}
+ * ```
+ *
  * Configuration | Type | Default | Description
  * --- | --- | --- | ---
  * `buttonStyle` | boolean | false | Whether to style the `target` to look like a button
@@ -57,16 +71,24 @@ export default Component.extend({
    * Adds a brand class to the target as btn-{brand}
    * @property brand
    * @type {String}
-   * @default ''
+   * @passed
    */
   brand: '',
   /**
    * Whether or not to style the target as a link or a button
    * @property buttonStyle
    * @type {Boolean}
-   * @default false
+   * @passed
    */
   buttonStyle: false,
+  /**
+   * Whether or not to treat the dropdown content component as a dropdown menu
+   * @property dropdownMenu
+   * @type {Boolean}
+   * @default false
+   * @passed
+   */
+  dropdownMenu: false,
 
   // Properties
   // ---------------------------------------------------------------------------
@@ -134,7 +156,8 @@ export default Component.extend({
    */
   actions: {
     /**
-     * Handle the showing of the dropdown
+     * Handle the showing of the dropdown. This will pass on any arguments you
+     * pass to it in the action.
      * @method show
      * @return {undefined}
      */
@@ -143,13 +166,14 @@ export default Component.extend({
       this.set('hidden', false);
 
       // Check for passed closures
-      if (this.get('onShow')) { this.get('onShow')(); }
+      if (this.get('onShow')) { this.get('onShow')(...arguments); }
 
       // Bind the keycommand `esc` to close dropdown
       bindOnEscape(this.get('elementId'), this.get('actions.hide').bind(this));
     },
     /**
-     * Handle the hiding of the dropdown
+     * Handle the hiding of the dropdown. This will pass on any arguments you
+     * pass to it in the action.
      * @method hide
      * @return {undefined}
      */
@@ -158,7 +182,7 @@ export default Component.extend({
       this.set('hidden', true);
 
       // Check for passed closures
-      if (this.get('onHide')) { this.get('onHide')(); }
+      if (this.get('onHide')) { this.get('onHide')(...arguments); }
 
       // Remove listeners
       unbindOnEscape(this.get('elementId'));
@@ -178,6 +202,7 @@ export default Component.extend({
 
     {{#if Target}}
       {{#rad-dropdown/target
+        aria-describedby=aria-describedby
         brand=brand
         click=(action (if hidden 'show' 'hide'))
         link=(not buttonStyle)
@@ -194,12 +219,17 @@ export default Component.extend({
 
     {{yield (hash
       target=(component 'rad-dropdown/target'
+        aria-describedby=aria-describedby
         brand=brand
         click=(action (if hidden 'show' 'hide'))
         link=(not buttonStyle)
         hidden=hidden)
       content=(component 'rad-dropdown/content'
+        dropdownMenu=dropdownMenu
         hidden=hidden)
+      menu-item=(component 'rad-dropdown/menu-item'
+        aria-describedby=aria-describedby
+        hide=(action 'hide'))
     ) (action 'show') (action 'hide') hidden aria-describedby aria-labelledby}}
   `
 });

--- a/addon/components/rad-dropdown/component.js
+++ b/addon/components/rad-dropdown/component.js
@@ -214,7 +214,7 @@ export default Component.extend({
 
     {{#if Target}}
       {{#rad-dropdown/target
-        aria-describedby=aria-describedby
+        aria-describedby=describedby
         brand=brand
         click=(action (if hidden 'show' 'hide'))
         link=(not buttonStyle)
@@ -231,7 +231,7 @@ export default Component.extend({
 
     {{yield (hash
       target=(component 'rad-dropdown/target'
-        aria-describedby=aria-describedby
+        aria-describedby=describedby
         brand=brand
         click=(action (if hidden 'show' 'hide'))
         link=(not buttonStyle)

--- a/addon/components/rad-dropdown/component.js
+++ b/addon/components/rad-dropdown/component.js
@@ -89,6 +89,18 @@ export default Component.extend({
    * @passed
    */
   dropdownMenu: false,
+  /**
+   * Fires when the dropdown is closed
+   * @property onHide
+   * @closure
+   */
+  onHide: () => {},
+  /**
+   * Fires when the dropdown is opened
+   * @property onShow
+   * @closure
+   */
+  onShow: () => {},
 
   // Properties
   // ---------------------------------------------------------------------------

--- a/addon/components/rad-dropdown/content/component.js
+++ b/addon/components/rad-dropdown/content/component.js
@@ -41,7 +41,10 @@ export default Component.extend({
    * @property attributeBindings
    * @type {Array}
    */
-  attributeBindings: ['hiddenForArias:aria-hidden'],
+  attributeBindings: [
+    'hiddenForArias:aria-hidden',
+    'aria-labelledby:aria-labelledby'
+  ],
   /**
    * Bind `dropdown-content`
    * @property classNames

--- a/addon/components/rad-dropdown/content/component.js
+++ b/addon/components/rad-dropdown/content/component.js
@@ -12,6 +12,18 @@ import { hiddenForArias } from '../../../utils/arias';
  * @extends Ember.Component
  */
 export default Component.extend({
+
+  // Passed Properties
+  // ---------------------------------------------------------------------------
+  /**
+   * Adds `dropdown-menu` class which removes padding in order to show
+   * dropdown menu items.
+   * @property dropdownMenu
+   * @type {Boolean}
+   * @passed
+   */
+  dropdownMenu: false,
+
   // Properties
   // ---------------------------------------------------------------------------
   /**
@@ -36,6 +48,12 @@ export default Component.extend({
    * @type {Array}
    */
   classNames: ['dropdown-content'],
+  /**
+   * Binds `dropdown-menu` class if {{cross-link class="Component.RadDropdown.Content" item="dropdownMenu"}} is true
+   * @property classNameBindings
+   * @type {Array}
+   */
+  classNameBindings: ['dropdownMenu:dropdown-menu'],
 
   // Layout
   // ---------------------------------------------------------------------------

--- a/addon/components/rad-dropdown/menu-item/component.js
+++ b/addon/components/rad-dropdown/menu-item/component.js
@@ -1,0 +1,40 @@
+import hbs from 'htmlbars-inline-precompile';
+import CoreButton from '../../rad-button/component';
+
+/**
+ * Core dropdown menu item
+ *
+ * @class Component.RadDropdown.MenuItem
+ * @constructor
+ * @extends Ember.CoreButton
+ */
+export default CoreButton.extend({
+  // Properties
+  // ---------------------------------------------------------------------------
+  /**
+   * Binds `dropdown-item` class
+   * @property classNames
+   * @type {Array}
+   */
+  classNames: ['dropdown-item'],
+  /**
+   * Override default click behavior and close the dropdown
+   * @event click
+   * @return {undefined}
+   */
+  click() {
+    this._super();
+    this.hide();
+  },
+  /**
+   * Closure action that hides the dropdown
+   * @method hide
+   * @return {undefined}
+   * @closure
+   */
+  hide() => {},
+
+  // Layout
+  // ---------------------------------------------------------------------------
+  layout: hbs`{{{yield}}}`
+});

--- a/addon/components/rad-dropdown/menu-item/component.js
+++ b/addon/components/rad-dropdown/menu-item/component.js
@@ -28,11 +28,10 @@ export default CoreButton.extend({
   },
   /**
    * Closure action that hides the dropdown
-   * @method hide
-   * @return {undefined}
+   * @property hide
    * @closure
    */
-  hide() => {},
+  hide: () => {},
 
   // Layout
   // ---------------------------------------------------------------------------

--- a/app/components/rad-dropdown/menu-item/component.js
+++ b/app/components/rad-dropdown/menu-item/component.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-radical/components/rad-dropdown/menu-item/component';

--- a/app/styles/ember-radical/component-structures/_dropdowns.scss
+++ b/app/styles/ember-radical/component-structures/_dropdowns.scss
@@ -25,7 +25,17 @@
 
 .dropdown-content {
   margin-top: 3px;
-  padding: 20px;
   position: absolute;
   z-index: 1091;
+
+  &.dropdown-menu {
+    padding: 0;
+  }
+}
+
+.dropdown-item {
+  display: block;
+  width: 100%;
+  border-radius: 0;
+  border: 0;
 }

--- a/app/styles/ember-radical/skeleton-theme/modules/_dropdowns.scss
+++ b/app/styles/ember-radical/skeleton-theme/modules/_dropdowns.scss
@@ -7,8 +7,18 @@
 }
 
 .dropdown-content {
-  background: white;
-  border: solid 1px $border-color;
+  padding: $dropdown-padding;
+  background: $dropdown-bg;
+  border: solid 1px $dropdown-border-color;
   border-radius: $border-radius;
   box-shadow: $box-shadow;
+  min-width: 10rem;
+}
+
+.dropdown-item {
+  &:hover,
+  &:focus {
+    background: $dropdown-item-hover-bg;
+    text-decoration: none;
+  }
 }

--- a/app/styles/ember-radical/skeleton-theme/utils/_variables.scss
+++ b/app/styles/ember-radical/skeleton-theme/utils/_variables.scss
@@ -152,6 +152,12 @@ $kbd-box-shadow: inset 0 -.1rem 0 rgba(0,0,0,.25);
 $pre-color: $body-color;
 $pre-scrollable-max-height: 340px;
 
+// Dropdowns
+// ---------------------------------------------------------------------------
+$dropdown-padding: 1rem;
+$dropdown-bg: white;
+$dropdown-border-color: $border-color;
+$dropdown-item-hover-bg: $gray-lighter;
 
 // Tables
 // ---------------------------------------------------------------------------

--- a/tests/integration/components/rad-dropdown/component-test.js
+++ b/tests/integration/components/rad-dropdown/component-test.js
@@ -30,6 +30,8 @@ test('it binds the required attributes', function(assert) {
   assert.equal(this.$('button').attr('aria-haspopup'), 'true', 'target should have popup aria attr');
   assert.equal(this.$('button').attr('aria-expanded'), 'false', 'target should have aria expanded false by default');
   assert.equal(this.$('.dropdown-content').attr('aria-hidden'), 'true', 'content should have aria-hidden true by default');
+  assert.equal(this.$('.dropdown-target').attr('id'), `lbldy-${this.$('.rad-dropdown').attr('id')}`, 'target should have proper id');
+  assert.equal(this.$('.dropdown-content').attr('aria-labelledby'), `lbldy-${this.$('.rad-dropdown').attr('id')}`, 'content should have aria-labelledby attr');
 });
 
 test('property buttonStyles binds the appropriate classes', function(assert) {
@@ -79,6 +81,37 @@ test('pressing escape closes the dropdown', function(assert) {
     e.which = 27; // escape key
     this.$(document).trigger(e);
   });
+
+  assert.equal(this.$('.dropdown-target').attr('aria-expanded'), 'false', 'target shows expanded false after pressing escape');
+  assert.equal(this.$('.dropdown-content').attr('aria-hidden'), 'true', 'content shows have aria-hidden true after pressing escape');
+  assert.equal(this.$('.dropdown-content').css('display'), 'none', 'content is not displayed after pressing escape');
+});
+
+test('use the dropdown as a dropdown menu', function(assert) {
+  this.render(hbs`
+    {{#rad-dropdown dropdownMenu=true as |components|}}
+      {{#components.target}}Dropdown Target{{/components.target}}
+      {{#components.content}}
+        {{#components.menu-item}}Dropdown Option{{/components.menu-item}}
+      {{/components.content}}
+    {{/rad-dropdown}}
+  `);
+
+  assert.ok(this.$('.dropdown-content').hasClass('dropdown-menu'), 'dropdown-menu class exists');
+  assert.equal(this.$('.dropdown-item').length, 1, 'a dropdown menu-item is rendered');
+});
+
+test('clicking a menu-item closes the dropdown', function(assert) {
+  this.render(hbs`
+    {{#rad-dropdown dropdownMenu=true as |components|}}
+      {{#components.target}}Dropdown Target{{/components.target}}
+      {{#components.content}}
+        {{#components.menu-item}}Dropdown Option{{/components.menu-item}}
+      {{/components.content}}
+    {{/rad-dropdown}}
+  `);
+
+  this.$('.dropdown-item').first().click();
 
   assert.equal(this.$('.dropdown-target').attr('aria-expanded'), 'false', 'target shows expanded false after pressing escape');
   assert.equal(this.$('.dropdown-content').attr('aria-hidden'), 'true', 'content shows have aria-hidden true after pressing escape');


### PR DESCRIPTION
<!-- Please use this helpful template for filing Pull Requests. -->
<!-- If you haven't read the contribution guide, please do before submitting a PR; it will likely save a lot of time during the review process. -->

## Description
Updates `rad-dropdown` to work better with bootstrap styles.

These are the changes included:

- :sparkles: Added `rad-dropdown/menu-item` for building radical dropdown menus
- :bug: Fixed issue with the way aria attrs were passed in dropdowns

## Tests
<!-- Don't lie about this, Travis CI will call you out pretty fast if you do -->
- [x] I added tests for changes I made
- [x] All tests are _definitely_ passing
