### PR TITLE
Rad new `code-example` (for the guides)

### DIFF
--- a/tests/dummy/app/components/code-example.js
+++ b/tests/dummy/app/components/code-example.js
@@ -34,6 +34,7 @@ export default Component.extend({
         </div>
         <div class="rendered-sample">
           {{!-- {{code}} --}}
+          {{! @TODO: get an auto-rendered version of the example, make it optional in case the functional version needs to differ from the example version }}
           {{yield}}
         </div>
       {{/components.body}}

--- a/tests/dummy/app/components/code-example.js
+++ b/tests/dummy/app/components/code-example.js
@@ -1,0 +1,42 @@
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+const { Component } = Ember;
+
+export default Component.extend({
+
+  code: '',
+
+  language: '',
+
+  showCode: false,
+
+  title: '',
+
+  actions: {
+    toggleCode() {
+      this.toggleProperty('showCode');
+    }
+  },
+
+  layout: hbs`
+    {{#rad-card as |components|}}
+      {{#components.title
+        classNames='code-card-title'}}
+        <span class="example-title">{{title}}</span>
+        {{#rad-button
+          brand='secondary'
+          classNames='code-toggle-button'
+          click=(action 'toggleCode')}}<b>&lt;/&gt;</b>{{/rad-button}}
+      {{/components.title}}
+      {{#components.body}}
+        <div class="code-sample {{if showCode '' 'hidden'}}">
+          {{highlight-code code=code language=language}}
+        </div>
+        <div class="rendered-sample">
+          {{!-- {{code}} --}}
+          {{yield}}
+        </div>
+      {{/components.body}}
+    {{/rad-card}}
+  `
+});

--- a/tests/dummy/app/components/code-example.js
+++ b/tests/dummy/app/components/code-example.js
@@ -1,22 +1,111 @@
 import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
-const { Component } = Ember;
+const { Component, HTMLBars, getOwner } = Ember;
 
 export default Component.extend({
+
+  // Passed Props
+  // ---------------------------------------------------------------------------
+
+  autoRender: true,
 
   code: '',
 
   language: '',
 
+  title: '',
+
+  // Props
+  // ---------------------------------------------------------------------------
+
+  classNames: ['code-example'],
+
+  codeBlockHeight: 0,
+
+  codeBlockHeightCSS: '',
+
+  renderPartialName: '',
+
   showCode: false,
 
-  title: '',
+  // Methods
+  // ---------------------------------------------------------------------------
+
+  _calculateCodeBlockHeight() {
+    let codeBlockHeight = this.$(this.$('.code-block pre')[0]).outerHeight();
+    this.set('codeBlockHeight', codeBlockHeight + 50);
+  },
+
+  _checkActionRefs(templateString) {
+
+    if (!templateString) { return; }
+
+    const firstFilter = /action\s"(\w*?)"/gim;
+    const secondFilter = /\'(.*?)\'/gi;
+    let matchedActions = templateString.match(firstFilter);
+
+    if (!matchedActions) { return; }
+
+    let actionNames = matchedActions.map(item => {
+      return item.replace(/\"/g, '\'').match(secondFilter)[0].replace(/\'/g, '');
+    });
+
+    // Loop through the list of actions and set up no-ops on the local context
+    // so that the test app doesn't explode
+    actionNames.forEach(action => {
+      if (!this.get(`actions.${action}`)) {
+        this.set(`actions.${action}`, function() {});
+        console.log(`Setting up a no-op for action name of ${action}`); //:brule:
+      }
+    });
+  },
+
+  _renderCode(templateString) {
+    try {
+      let uniqueId = `${this.get('elementId')}-render-result`;
+
+      // Ensure non-existant passed in actions don't cause the app to explode
+      this._checkActionRefs(templateString);
+
+      // Compile the string into a template and register it on the container
+      getOwner(this).register(`template:partials/${uniqueId}`, HTMLBars.compile(templateString));
+      // Update the reference of the preview's partialName to match the newly generated partial
+      this.set('renderPartialName', `partials/${uniqueId}`);
+    } catch(ex) {
+      this.set('renderPartialName', '');
+      console.warn(ex);
+    }
+  },
+
+  // Hooks
+  // ---------------------------------------------------------------------------
+
+  didInsertElement() {
+    if (this.get('autoRender')) {
+      this._renderCode(this.get('code'));
+      this._calculateCodeBlockHeight();
+    }
+  },
+
+  init() {
+    this._super(...arguments);
+    this.set('codeBlockHeightCSS', Ember.String.htmlSafe('max-height: 0px;'));
+  },
+
+  // Actions
+  // ---------------------------------------------------------------------------
 
   actions: {
     toggleCode() {
       this.toggleProperty('showCode');
+      let heightValue = this.get('showCode') ? this.get('codeBlockHeight') : 0;
+      let heightCSS = Ember.String.htmlSafe(`max-height: ${heightValue}px;`);
+      this.set('codeBlockHeightCSS', heightCSS);
     }
   },
+
+  // Layout
+  // ---------------------------------------------------------------------------
 
   layout: hbs`
     {{#rad-card as |components|}}
@@ -29,12 +118,13 @@ export default Component.extend({
           click=(action 'toggleCode')}}<b>&lt;/&gt;</b>{{/rad-button}}
       {{/components.title}}
       {{#components.body}}
-        <div class="code-sample {{if showCode '' 'hidden'}}">
+        <div class="code-block{{if showCode '' ' hidden'}}" style={{codeBlockHeightCSS}}>
           {{highlight-code code=code language=language}}
         </div>
-        <div class="rendered-sample">
-          {{!-- {{code}} --}}
-          {{! @TODO: get an auto-rendered version of the example, make it optional in case the functional version needs to differ from the example version }}
+        <div class="rendered-example">
+          {{#if autoRender}}
+            {{partial renderPartialName}}
+          {{/if}}
           {{yield}}
         </div>
       {{/components.body}}

--- a/tests/dummy/app/components/code-example.js
+++ b/tests/dummy/app/components/code-example.js
@@ -92,6 +92,12 @@ export default Component.extend({
     this.set('codeBlockHeightCSS', Ember.String.htmlSafe('max-height: 0px;'));
   },
 
+  willDestroyElement() {
+    if (!this.get('isDestroyed')) {
+      getOwner(this).unregister(`template:${this.get('renderPartialName')}`);
+    }
+  },
+
   // Actions
   // ---------------------------------------------------------------------------
 

--- a/tests/dummy/app/styles/dummy-styles/_guide-page.scss
+++ b/tests/dummy/app/styles/dummy-styles/_guide-page.scss
@@ -60,14 +60,23 @@
   }
 }
 
-.code-sample {
-  margin-bottom: 1em;
-  padding-bottom: 1em;
-  border-bottom: 1px solid $brand-primary;
-  transition: all 0.2s ease;
-  &.hidden {
-    display: none;
-    height: 0;
+.code-example {
+  .code-block {
+    overflow: hidden;
+    height: auto;
+    max-height: 500px;
+    margin-bottom: 1em;
+    padding-bottom: 1em;
+    border-bottom: 1px solid $brand-primary;
+    transition: all 0.3s ease-in;
+
+    &.hidden {
+      max-height: 0;
+      margin: 0;
+      padding: 0;
+      border: none;
+      transition: all 0.3s ease-out;
+    }
   }
 }
 

--- a/tests/dummy/app/styles/dummy-styles/_guide-page.scss
+++ b/tests/dummy/app/styles/dummy-styles/_guide-page.scss
@@ -45,6 +45,32 @@
   }
 }
 
+// Code Examples
+.code-card-title {
+  display: flex;
+
+  align-items: center;
+
+  button.code-toggle-button {
+    display: flex;
+  }
+
+  .example-title {
+    flex: 1;
+  }
+}
+
+.code-sample {
+  margin-bottom: 1em;
+  padding-bottom: 1em;
+  border-bottom: 1px solid $brand-primary;
+  transition: all 0.2s ease;
+  &.hidden {
+    display: none;
+    height: 0;
+  }
+}
+
 p.enums {
   margin-bottom: 0;
 }

--- a/tests/dummy/app/templates/getting-started/buttons.hbs
+++ b/tests/dummy/app/templates/getting-started/buttons.hbs
@@ -12,6 +12,12 @@
     {{/components.body}}
   {{/rad-card}}
 
+  {{#code-example
+    title='Basic Example'
+    language='handlebars' code="{{#rad-button}}SAMPLE BUTTON!{{/rad-button}}"}}
+    {{#rad-button}}SAMPLE BUTTON!{{/rad-button}}
+  {{/code-example}}
+
   <br>
 
   {{#rad-card as |components|}}

--- a/tests/dummy/app/templates/getting-started/buttons.hbs
+++ b/tests/dummy/app/templates/getting-started/buttons.hbs
@@ -5,29 +5,17 @@
 <section>
   <h3>Examples</h3>
 
-  {{#rad-card as |components|}}
-    {{#components.title}}Basic Examples{{/components.title}}
-    {{#components.body}}
-      {{#rad-button}}Hey, I'm a rad button!{{/rad-button}}
-    {{/components.body}}
-  {{/rad-card}}
-
-  {{#code-example
+  {{code-example
     title='Basic Example'
-    language='handlebars' code="{{#rad-button}}SAMPLE BUTTON!{{/rad-button}}"}}
-    {{#rad-button}}SAMPLE BUTTON!{{/rad-button}}
-  {{/code-example}}
+    language='handlebars' code="{{#rad-button}}Hey, I'm a rad button!{{/rad-button}}"}}
 
   <br>
 
-  {{#rad-card as |components|}}
-    {{#components.title}}Extended Options{{/components.title}}
-    {{#components.body}}
-      {{#rad-button brand="primary"}}Primary Brand Button{{/rad-button}}
-      {{#rad-button brand="secondary"}}Secondary Brand Button{{/rad-button}}
-      {{#rad-button link="true"}}Link/Anchor-like Button{{/rad-button}}
-    {{/components.body}}
-  {{/rad-card}}
+  {{code-example
+    title='Extended Options'
+    language='handlebars' code="{{#rad-button brand='primary'}}Primary Brand Button{{/rad-button}}
+{{#rad-button brand='secondary'}}Secondary Brand Button{{/rad-button}}
+{{#rad-button link='true'}}Link/Anchor-like Button{{/rad-button}}"}}
 </section>
 <section>
   <h3>Properties</h3>

--- a/tests/dummy/app/templates/getting-started/cards.hbs
+++ b/tests/dummy/app/templates/getting-started/cards.hbs
@@ -4,43 +4,37 @@
 <section>
   <h3>Examples</h3>
 
-  {{#rad-card as |components|}}
-    {{#components.title}}Basic Examples{{/components.title}}
-    {{#components.body}}
-      {{#rad-card as |components|}}
-        {{#components.body}}Simple card{{/components.body}}
-      {{/rad-card}}
-    {{/components.body}}
-  {{/rad-card}}
+  {{code-example
+    title='Basic Example'
+    language='handlebars' code="{{#rad-card as |components|}}
+  {{#components.body}}Simple card{{/components.body}}
+{{/rad-card}}"}}
 
-  {{#rad-card as |components|}}
-    {{#components.title}}Extended Examples{{/components.title}}
-    {{#components.body}}
-      {{#rad-card as |components|}}
-        {{#components.title}}Simple card w/ header{{/components.title}}
-        {{#components.body}}Some content{{/components.body}}
-      {{/rad-card}}
+  {{code-example
+    title='Extended Examples'
+    language='handlebars' code="{{#rad-card as |components|}}
+  {{#components.title}}Simple card w/ header{{/components.title}}
+  {{#components.body}}Some content{{/components.body}}
+{{/rad-card}}
 
-      {{#rad-card as |components|}}
-        {{#components.title}}Simple card w/ header and footer{{/components.title}}
-        {{#components.body}}Some content{{/components.body}}
-        {{#components.footer}}Footer content{{/components.footer}}
-      {{/rad-card}}
+{{#rad-card as |components|}}
+  {{#components.title}}Simple card w/ header and footer{{/components.title}}
+  {{#components.body}}Some content{{/components.body}}
+  {{#components.footer}}Footer content{{/components.footer}}
+{{/rad-card}}
 
-      {{#rad-card brand="primary" as |components|}}
-        {{#components.title}}Branded Header{{/components.title}}
-        {{#components.body}}Some content{{/components.body}}
-      {{/rad-card}}
+{{#rad-card brand='primary' as |components|}}
+  {{#components.title}}Branded Header{{/components.title}}
+  {{#components.body}}Some content{{/components.body}}
+{{/rad-card}}
 
-      {{#rad-card brand="primary" as |components|}}
-        {{#components.title}}Branded card w/ custom content{{/components.title}}
-        {{#components.body}}
-          {{#rad-button}}Button{{/rad-button}}
-        {{/components.body}}
-        {{#components.footer}}Footer content{{/components.footer}}
-      {{/rad-card}}
-    {{/components.body}}
-  {{/rad-card}}
+{{#rad-card brand='primary' as |components|}}
+  {{#components.title}}Branded card w/ custom content{{/components.title}}
+  {{#components.body}}
+    {{#rad-button}}Button{{/rad-button}}
+  {{/components.body}}
+  {{#components.footer}}Footer content{{/components.footer}}
+{{/rad-card}}"}}
 
 </section>
 <section>


### PR DESCRIPTION
## Description

This adds a totally rad new feature for our guide pages that will make it easier for us to write our docs! It outputs a rendered version of the supplied code and a button to show the markup used to make the example real. PRETTY COOL. Auto-rendering can be disabled in favor of invoking the component in block form if your rendered version needs different markup to work within the context of the app.

There's some extra code added to deal with making the CSS animations on showing and hiding the code blocks smoother. I feel like it's worth the little bit of extra work.

- :sparkles: ~~PRETTY COOL~~ TOTALLY RAD CODE EXAMPLES IN OUR GUIDES

## Tests
- [x] All tests are _definitely_ passing
