### PR TITLE
🐛 Fixes false negative on modal accessibility check in an edge case

### DIFF
--- a/addon/components/rad-modal.js
+++ b/addon/components/rad-modal.js
@@ -409,9 +409,11 @@ export default Component.extend({
       // aria-labelledby is required for A++ Accessibility
       const elementId = this.get('elementId');
       const headerId = `#aria-labelledby-${elementId}`;
-      if (!$(headerId).is('header')) {
+      // @TODO: Figure out how to make this check _reliably_ for modals that
+      // have `removeFromDomOnClose` enabled
+      if (!this.get('removeFromDomOnClose') && !$(headerId).is('header')) {
         console.image('https://media.giphy.com/media/6Bfnhb5jQqvny/giphy.gif', 2);
-        throw new Error('{{rad-modal}}: You must specify a modal header or supply an `ariaHeader` string, ya dongus');
+        throw new Error('{{rad-modal}}: You must specify a modal header or supply an `ariaHeader` string, ya dongus', headerId);
       }
     }
   },


### PR DESCRIPTION
## Description
If a `rad-modal` had the `removeFromDomOnClose` property set to `true`, the accessibility compliance check on the modal header would fail because its contents would not actually exist in the DOM at the time of the check taking place.

This PR disables the check for modals which have`removeFromDomOnClose` enabled, until we can figure out a better, proper fix that covers that use case as well. The side effect of this is that for now, it is possible to create headers which are NOT compliant if you use this property, but that is a pretty mega fringe case.

- :bug: Fixed a potentially erroneous error being thrown for modals using `removeFromDomOnClose`

## Tests
- [ ] All tests are _definitely_ passing
