### PR TITLE
:sparkles: Radical ability to specify the component used for contextual component

### DIFF
--- a/addon/components/rad-card.js
+++ b/addon/components/rad-card.js
@@ -59,6 +59,34 @@ export default Component.extend({
    */
   cardTitleClassNames: 'card-title',
 
+  // Contextual Component Specifications
+  // ---------------------------------------------------------------------------
+
+  /**
+   * @property bodyComponent
+   * @type {string}
+   * @passed
+   * @optional
+   * @default 'rad-card/body'
+   */
+  bodyComponent: 'rad-card/body',
+  /**
+   * @property footerComponent
+   * @type {string}
+   * @passed
+   * @optional
+   * @default 'rad-card/footer'
+   */
+  footerComponent: 'rad-card/footer',
+  /**
+   * @property titleComponent
+   * @type {string}
+   * @passed
+   * @optional
+   * @default 'rad-card/title'
+   */
+  titleComponent: 'rad-card/title',
+
   // Properties
   // ---------------------------------------------------------------------------
 
@@ -94,11 +122,11 @@ export default Component.extend({
   // ---------------------------------------------------------------------------
   layout: hbs`
     {{yield (hash
-      title=(component 'rad-card/title'
+      title=(component titleComponent
         cardTitleClassNames=cardTitleClassNames)
-      body=(component 'rad-card/body'
+      body=(component bodyComponent
         cardBodyClassNames=cardBodyClassNames)
-      footer=(component 'rad-card/footer'
+      footer=(component footerComponent
         cardFooterClassNames=cardFooterClassNames)
     )}}
   `

--- a/addon/components/rad-drawer.js
+++ b/addon/components/rad-drawer.js
@@ -120,6 +120,26 @@ export default Component.extend({
    */
   icon: 'arrow-down',
 
+  // Contextual Component Specifications
+  // ---------------------------------------------------------------------------
+
+  /**
+   * @property contentComponent
+   * @type {string}
+   * @passed
+   * @optional
+   * @default 'rad-drawer/content'
+   */
+  contentComponent: 'rad-drawer/content',
+  /**
+   * @property contentComponent
+   * @type {string}
+   * @passed
+   * @optional
+   * @default 'rad-drawer/content'
+   */
+  targetComponent: 'rad-drawer/target',
+
   // Properties
   // ---------------------------------------------------------------------------
 
@@ -219,11 +239,11 @@ export default Component.extend({
     {{/if}}
 
     {{yield (hash
-      content=(component 'rad-drawer/content'
+      content=(component contentComponent
         ariaId=ariaId
         hidden=hidden
         data-test=data-test)
-      target=(component 'rad-drawer/target'
+      target=(component targetComponent
         ariaId=ariaId
         click=(action 'toggleHidden')
         hidden=hidden

--- a/addon/components/rad-dropdown.js
+++ b/addon/components/rad-dropdown.js
@@ -120,6 +120,34 @@ export default Component.extend({
    * @optional
    */
 
+  // Contextual Component Specifications
+  // ---------------------------------------------------------------------------
+
+  /**
+   * @property contentComponent
+   * @type {string}
+   * @passed
+   * @optional
+   * @default 'rad-dropdown/content'
+   */
+  contentComponent: 'rad-dropdown/content',
+  /**
+   * @property menuItemComponent
+   * @type {string}
+   * @passed
+   * @optional
+   * @default 'rad-dropdown/menu-item'
+   */
+  menuItemComponent: 'rad-dropdown/menu-item',
+  /**
+   * @property menuItemComponent
+   * @type {string}
+   * @passed
+   * @optional
+   * @default 'rad-dropdown/target'
+   */
+  targetComponent: 'rad-dropdown/target',
+
   // Properties
   // ---------------------------------------------------------------------------
   /**
@@ -309,17 +337,17 @@ export default Component.extend({
 
     {{yield
       (hash
-        target=(component 'rad-dropdown/target'
+        target=(component targetComponent
           id=(concat 'aria-labelledby-' elementId)
           brand=brand
           click=(action (if hidden 'show' 'hide'))
           link=(not buttonStyle)
           hidden=hidden)
-        content=(component 'rad-dropdown/content'
+        content=(component contentComponent
           aria-labelledby=(concat 'aria-labelledby-' elementId)
           dropdownMenu=dropdownMenu
           hidden=hidden)
-        menu-item=(component 'rad-dropdown/menu-item'
+        menu-item=(component menuItemComponent
           hide=(action 'hide'))
       )
       (action 'show')

--- a/addon/components/rad-modal.js
+++ b/addon/components/rad-modal.js
@@ -241,6 +241,26 @@ export default Component.extend({
    */
   closeModal: () => {},
 
+  // Contextual Component Specifications
+  // ---------------------------------------------------------------------------
+
+  /**
+   * @property footerComponent
+   * @type {string}
+   * @passed
+   * @optional
+   * @default 'rad-modal/footer'
+   */
+  footerComponent: 'rad-modal/footer',
+  /**
+   * @property headerComponent
+   * @type {string}
+   * @passed
+   * @optional
+   * @default 'rad-modal/header'
+   */
+  headerComponent: 'rad-modal/header',
+
   // Properties
   // ---------------------------------------------------------------------------
 
@@ -499,13 +519,13 @@ export default Component.extend({
         {{! ----------------------------------------------------------------- }}
         {{yield
           (hash
-            header=(component 'rad-modal/header'
+            header=(component headerComponent
               closeModal=closeModal
               elementId=(concat 'aria-labelledby-' elementId)
               closeButton=closeButton
               tagClose=tagClose
             )
-            footer=(component 'rad-modal/footer')
+            footer=(component footerComponent)
           )
           open
         }}

--- a/addon/components/rad-popover.js
+++ b/addon/components/rad-popover.js
@@ -86,6 +86,26 @@ export default Component.extend({
    */
   size: '',
 
+  // Contextual Component Specifications
+  // ---------------------------------------------------------------------------
+
+  /**
+   * @property contentComponent
+   * @type {string}
+   * @passed
+   * @optional
+   * @default 'rad-popover/content'
+   */
+  contentComponent: 'rad-popover/content',
+  /**
+   * @property targetComponent
+   * @type {string}
+   * @passed
+   * @optional
+   * @default 'rad-button'
+   */
+  targetComponent: 'rad-button',
+
   // Properties
   // ---------------------------------------------------------------------------
 
@@ -198,13 +218,13 @@ export default Component.extend({
 
   layout: hbs`
     {{yield (hash
-      content=(component 'rad-popover/content'
+      content=(component contentComponent
         aria-describedby=aria-describedby
         hidden=hidden
         position=position
         size=size
         data-test=(concat data-test '-content'))
-      target=(component 'rad-button'
+      target=(component targetComponent
         aria-describedby=aria-describedby
         data-test=(concat data-test '-target'))
       ) aria-describedby

--- a/addon/components/rad-tabs.js
+++ b/addon/components/rad-tabs.js
@@ -178,6 +178,18 @@ export default Component.extend({
    */
   tabListClassNames: '',
 
+  // Contextual Component Specifications
+  // ---------------------------------------------------------------------------
+
+  /**
+   * @property contentComponent
+   * @type {string}
+   * @passed
+   * @optional
+   * @default 'rad-tabs/content'
+   */
+  contentComponent: 'rad-tabs/content',
+
   // Properties
   // ---------------------------------------------------------------------------
 
@@ -331,7 +343,7 @@ export default Component.extend({
     <div class="content-container {{if card 'rad-card'}}">
       {{! Yield the rad-tabs/content component pre-bound with internal props }}
       {{yield (hash
-        content=(component 'rad-tabs/content'
+        content=(component contentComponent
           registerTab=(action 'registerTab')
           updateTab=(action 'updateTab')
           activeId=activeId)

--- a/addon/components/rad-tooltip.js
+++ b/addon/components/rad-tooltip.js
@@ -76,6 +76,26 @@ export default Component.extend({
    */
   onShow: null,
 
+  // Contextual Component Specifications
+  // ---------------------------------------------------------------------------
+
+  /**
+   * @property contentComponent
+   * @type {string}
+   * @passed
+   * @optional
+   * @default 'rad-tooltip/content'
+   */
+  contentComponent: 'rad-tooltip/content',
+  /**
+   * @property titleComponent
+   * @type {string}
+   * @passed
+   * @optional
+   * @default 'rad-tooltip/title'
+   */
+  titleComponent: 'rad-tooltip/title',
+
   // Properties
   // ---------------------------------------------------------------------------
 
@@ -185,7 +205,7 @@ export default Component.extend({
     {{/if}}
 
     {{yield (hash
-      title=(component 'rad-tooltip/title'
+      title=(component titleComponent
         aria-describedby=aria-describedby
         brand=brand
         link=(not buttonStyle)
@@ -194,7 +214,7 @@ export default Component.extend({
         taglabel=taglabel
         tagvalue=tagvalue
         tagcd=tagcd)
-      content=(component 'rad-tooltip/content'
+      content=(component contentComponent
         aria-describedby=aria-describedby
         hidden=hidden)
     ) aria-describedby hidden}}


### PR DESCRIPTION
<!-- Please use this helpful template for filing Pull Requests. -->
<!-- If you haven't read the contribution guide, please do before submitting a PR; it will likely save a lot of time during the review process. -->

## Description
<!-- Explanation about your PR, summarize what changes you've made. -->
<!-- If an issue exists for your issue, PLEASE reference it here! -->
As we've found out sometimes passing class names isn't enough. Sometimes you need to extend a contextual component directly. This PR solves that issue by using properties with all contextual
components to specify the component path. On as needed basis you can now specify a different component to use for a contextual component.

These are the changes included:

- :sparkles: Property drives contextual component lookups 🎆  🎆  🎆 

We should do a separate page in the guides about how you can use this as it's a foundation pattern and doesn't make sense to document over and over on every component. I'm adding a task in our repo project for that.

## Tests
<!-- Don't lie about this, Travis CI will call you out pretty fast if you do -->
- [ ] I added tests for changes I made
- [x] All tests are _definitely_ passing
