### PR TITLE
:bug: Add touch event for buttons or links inside of dropdown content.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 Fixed:
+- 🐛 `rad-dropdown` now supports touch events inside of `dropdown-content`
 - 🐛 `rad-tabs` now yields the correct property for the active tab id (`activeId`)
 
 ## 1.2.0 (02-07-2017)

--- a/addon/components/rad-dropdown/content.js
+++ b/addon/components/rad-dropdown/content.js
@@ -58,6 +58,23 @@ export default Component.extend({
    */
   classNameBindings: ['dropdownMenu:dropdown-menu'],
 
+  // Events
+  //----------------------------------------------------------------------------
+
+  /**
+   * Nasty touch eventses. Tricksy touch eventses. Any short touch event on this
+   * content component will fire the focusOut and the mouseLeave on the
+   * `rad-popover` element. Real abnoxious when you're trying to click something.
+   * Fire the link or button manually. Through the wonderful power of JavaScript.
+   *
+   * @event touchEnd
+   */
+  touchEnd(evt) {
+    if(evt.target.tagName === 'A' || evt.target.tagName === 'BUTTON') {
+      evt.target.click();
+    }
+  },
+
   // Layout
   // ---------------------------------------------------------------------------
   layout: hbs`{{{yield}}}`


### PR DESCRIPTION
<!-- Please use this helpful template for filing Pull Requests. -->
<!-- If you haven't read the contribution guide, please do before submitting a PR; it will likely save a lot of time during the review process. -->

## Description
Fixes bug where touchevents weren't firing button and link click events inside of the dropdown content component.

These are the changes included:

- :bug: Fixed issue with button and link clicks in dropdowns

## Tests
<!-- Don't lie about this, Travis CI will call you out pretty fast if you do -->
- [ ] I added tests for changes I made
- [x] All tests are _definitely_ passing
