### PR TITLE
🐛 Fixes rad dropdown and rad popover behavior on mobile

### DIFF
--- a/addon/components/rad-dropdown.js
+++ b/addon/components/rad-dropdown.js
@@ -217,7 +217,7 @@ export default Component.extend({
    * @protected
    */
   _bindDropdownListeners() {
-    $('body').on(`mouseup.${this.get('elementId')}`, e => {
+    $('body').on(`mouseup.${this.get('elementId')} touchend.${this.get('elementId')}`, e => {
       // Check if the click was inside the dropdown
       let clickInDropdown = $(e.target).closest(`#${this.get('elementId')}`).length ? true : false;
 
@@ -230,11 +230,11 @@ export default Component.extend({
   /**
    * Remove click listener from body. Used to DRY up our cleanup code in the
    * supported click and mouse out close liseners.
-   * @method _unbindClickListener
+   * @method _unbindDropdownListeners
    * @protected
    */
-  _unbindClickListener() {
-    $('body').off(`mouseup.${this.get('elementId')}`);
+  _unbindDropdownListeners() {
+    $('body').off(`mouseup.${this.get('elementId')} touchend.${this.get('elementId')}`);
   },
 
   // Hooks
@@ -251,7 +251,7 @@ export default Component.extend({
     if (this.get('onDestroy')) { this.get('onDestroy')(); }
 
     // Remove listeners
-    this._unbindClickListener();
+    this._unbindDropdownListeners();
     unbindOnEscape(this.get('elementId'));
   },
 
@@ -329,7 +329,7 @@ export default Component.extend({
       this.set('hidden', true);
 
       // Remove listeners
-      this._unbindClickListener();
+      this._unbindDropdownListeners();
       unbindOnEscape(this.get('elementId'));
 
       // Fire user hooks

--- a/addon/components/rad-dropdown/content.js
+++ b/addon/components/rad-dropdown/content.js
@@ -77,13 +77,13 @@ export default Component.extend({
   classNameBindings: ['dropdownMenu:dropdown-menu', 'position'],
 
   // Events
-  //----------------------------------------------------------------------------
-
+  // ---------------------------------------------------------------------------
   /**
    * Nasty touch eventses. Tricksy touch eventses. Any short touch event on this
    * content component will fire the focusOut and the mouseLeave on the
-   * `rad-popover` element. Real abnoxious when you're trying to click something.
-   * Fire the link or button manually. Through the wonderful power of JavaScript.
+   * `rad-dropdown` element. Real abnoxious when you're trying to click
+   * something. Fire the link or button manually. Through the wonderful power
+   * of JavaScript.
    *
    * @event touchEnd
    */


### PR DESCRIPTION
## Summary

Addresses #84:

Rad Dropdowns and Rad Popovers could not be closed on mobile devices/touch screens; no event listeners had been set up to handle this behavior.

These things now happen for these components! Hurray! Also Rad Popover sneakily yields its new `hide` and `show` actions as well as its `hidden` state.

## Tests
- ~[ ] I added tests for changes I made~
- [ ] All tests are _definitely_ passing
