### PR TITLE
passes the modified data test attribute in all cases within the core drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.5.2 (03-20-2017)
+Fixed:
+- 🐛 Passes down `${data-test}-target` to `rad-drawer.content` in all situations and not just when Content is declared.
+
 ## 1.5.1 (03-15-2017)
 Fixed:
 - 🐛 Rad Dropdowns and Rad Popovers can now be closed on touch screen devices by tapping anywhere outside of their content [#84]
@@ -17,7 +21,7 @@ Added:
 - ⬆️ Updated to Ember CLI 2.11
 
 Fixed:
-- 🐛 `rad-dropdown` child component `menu-item`s will now correctly close the dropdown on click when a custom click action is passed in 
+- 🐛 `rad-dropdown` child component `menu-item`s will now correctly close the dropdown on click when a custom click action is passed in
 
 ## 1.3.3 (02-17-2017)
 Fixed:

--- a/addon/components/rad-drawer.js
+++ b/addon/components/rad-drawer.js
@@ -256,7 +256,7 @@ export default Component.extend({
         icon=icon
         link=(not buttonStyle)
         tagcategory=tagcategory tagaction=tagaction taglabel=taglabel tagvalue=tagvalue tagcd=tagcd
-        data-test=(if data-test (concat data-test '-target')))
+        data-test=data-test)
     ) hidden}}
 
     {{#if Content}}

--- a/addon/components/rad-drawer.js
+++ b/addon/components/rad-drawer.js
@@ -256,7 +256,7 @@ export default Component.extend({
         icon=icon
         link=(not buttonStyle)
         tagcategory=tagcategory tagaction=tagaction taglabel=taglabel tagvalue=tagvalue tagcd=tagcd
-        data-test=data-test)
+        data-test=(if data-test (concat data-test '-target')))
     ) hidden}}
 
     {{#if Content}}


### PR DESCRIPTION
REGRESSION | data-test attribute removed from UI | INTEGRATION

result expected: 
modified data-test attribute passes to rad-drawer.target

result actual:
the data-test was just passed down w/o the `-target` included onto the target.

These are the changes included:
- :bug: Fixed a silly bug!


## Tests
I actually couldn't get the app running on my local cuz i suck, so  I didn't check the tests. but :crossed_fingers:. I actually think there is a test that is only passing right now because it isn't finding the element to perform `hasClass` on and it is expecting `notOk`. 
