### PR TITLE
Use babel-inline-replace for env variables and clean up index.js a lo…

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,4 +1,5 @@
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+const packageJSON = require('./package.json');
 
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
@@ -10,6 +11,13 @@ module.exports = function(defaults) {
     // docs meta which doesn't get updated with fingerprint hash
     fingerprint: {
       exclude: ['ember-logo']
+    },
+
+    // Inline replace the version in the dummy app using babel
+    babel: {
+      plugins: [
+        ['inline-replace-variables', { RAD_VERSION: packageJSON.version || '0.0.0' }]
+      ]
     }
   });
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 'use strict';
-const packageJSON = require('./package.json');
 
 /**
  * Read in consuming application's options and feature flags to configure Radical
@@ -14,17 +13,6 @@ module.exports = {
   // Properties
   // ---------------------------------------------------------------------------
   /**
-   * Options for configuring addon. All default options should be specified here.
-   * These defaults are assigned to the consuming app's specified options in the
-   * `included` hook.
-   * @property addonOptions
-   * @type {Object}
-   */
-  addonOptions: {
-    consoleImage: true,
-    stripCode: true
-  },
-  /**
    * Default feature flags for features used in Radical code should be specified
    * here. These are merged with the consuming app's feature flags in the
    * `included` hook
@@ -32,7 +20,6 @@ module.exports = {
    * @type {Object}
    */
   featureFlags: {
-    RAD_VERSION: packageJSON.version || '0.0.0',
     TAGGING: false
   },
 
@@ -40,80 +27,32 @@ module.exports = {
   // ---------------------------------------------------------------------------
   /**
    * Recommended hook for including vendor files and setting configuration
-   * options. Ember Radical imports a console library in dev environments for
-   * radical logging messages and injects feature flags into consuming apps when
-   * stripCode is disabled.
+   * options. Handle merging consumer configs with default addon configs. Import
+   * console image library in dev.
    * @method included
-   * @param {Object} app Addon consumer, (can be an app or addon)
+   * @param {Object} app Addon consumer (can be an app or addon)
    */
-  included: function(app) {
+  included(app) {
     this._super.included.apply(this, arguments);
     this.env = process.env.EMBER_ENV || 'development';
 
     // Ensure `app` is consuming application by crawling addon tree
     while (typeof app.import !== 'function' && app.app) { app = app.app; }
 
-    // Merge default addon options with any configured options
-    app.options = app.options || {};
-    app.options.emberRadical = app.options.emberRadical || {};
-    this.addonOptions = Object.assign(this.addonOptions, app.options.emberRadical);
-
     // Merge the default addon feature flags with those configured by consuming app
     this.featureFlags = Object.assign(
       this.featureFlags,
-      this.project.config(this.env).featureFlags,
-      { NODE_ENV: this.env }
+      this.project.config(this.env).featureFlags
     );
 
-    // Import console image library into application unless disabled
-    if (this.addonOptions.consoleImage) {
-      app.import(`${this.treePaths.vendor}/console-image.js`); // Radical dev logging messages
-    }
+    this.options = this.options || {};
+    this.options.babel = this.options.babel || {};
+    this.options.babel.plugins = this.options.babel.plugins || [];
+    this.options.babel.plugins.push(
+      ['inline-replace-variables', Object.assign({ NODE_ENV: this.env }, this.featureFlags)]
+    );
 
-    // In prod builds configre UglifyJS to strip unreachable code with build variables
-    if (this.addonOptions.stripCode && this.env === 'production') {
-      app.options.minifyJS = app.options.minifyJS || {};
-      app.options.minifyJS.options = app.options.minifyJS.options || {};
-      let minifyOpts = app.options.minifyJS.options;
-
-      minifyOpts.enabled = true; // If you want to remove unreachable code, uglify must be enabled
-      minifyOpts.compress = minifyOpts.compress || {};
-      minifyOpts.compress.dead_code = true; // Prunes dead code
-      minifyOpts.compress.global_defs = minifyOpts.compress.global_defs || {};
-
-      for (let flag in this.featureFlags) {
-        minifyOpts.compress.global_defs[flag] = this.featureFlags[flag];
-      }
-    }
-  },
-  /**
-   * Handle setting no-ops/globals for Radical features that require them. The
-   * returned string below is added to the consuming application in the
-   * `{{content-for "head"}}` outlet. See
-   * https://github.com/emberyvr/content-for/blob/master/README.md for examples
-   * @method contentFor
-   * @param {string} type The type of content for outlet, allows you to target
-   * specific outlets
-   * @return {string} Content that is injected into the content-for outlet. We
-   *                  return a `<script>` that handles creating globals/no-ops for
-   *                  Radical features that require them.
-   */
-  contentFor(type) {
-    if (
-      (this.env !== 'production' || this.addonOptions.stripCode === false)
-      && type === 'head'
-    ) {
-      return `
-      <script>/* These flags are auto-generated in Ember Radical's contentFor hook */
-      var featureFlags = ${JSON.stringify(this.featureFlags)};
-
-      for (var feature in featureFlags) {
-        if (featureFlags.hasOwnProperty(feature)) {
-          window[feature] = featureFlags[feature];
-        }
-      };
-      ${this.addonOptions.consoleImage ? '' : 'console.image = function() {};'}
-      </script>`;
-    }
+    // Import a truly Radical dev logging library (dev only)
+    app.import(`${this.treePaths.vendor}/console-image${this.env === 'production' ? '-shim' : ''}.js`);
   }
 };

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "svgdefs": "svg-sprite --defs --defs-dest=tests/dummy/public/assets --defs-sprite=symbol-defs.svg tests/dummy/public/svgs/*.svg"
   },
   "dependencies": {
+    "babel-plugin-inline-replace-variables": "^1.3.1",
     "bootstrap": "4.0.0-alpha.6",
     "ember-cli-babel": "^6.0.0",
     "ember-cli-htmlbars": "^1.1.1",

--- a/vendor/console-image-shim.js
+++ b/vendor/console-image-shim.js
@@ -1,0 +1,3 @@
+(function() {
+  console.image = function() {};
+})();

--- a/yarn.lock
+++ b/yarn.lock
@@ -595,6 +595,12 @@ babel-plugin-inline-environment-variables@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz#1f58ce91207ad6a826a8bf645fafe68ff5fe3ffe"
 
+babel-plugin-inline-replace-variables@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-inline-replace-variables/-/babel-plugin-inline-replace-variables-1.3.1.tgz#9fbb8dd43229c777695e14ea0d3d781f048fdc0f"
+  dependencies:
+    babylon "^6.17.0"
+
 babel-plugin-jscript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz#8f342c38276e87a47d5fa0a8bd3d5eb6ccad8fcc"


### PR DESCRIPTION
…t :fireworks:

<!-- Please use this helpful template for filing Pull Requests. -->
<!-- If you haven't read the contribution guide, please do before submitting a PR; it will likely save a lot of time during the review process. -->

## Description
<!-- Explanation about your PR, summarize what changes you've made. -->
<!-- If an issue exists for your issue, PLEASE reference it here! -->

Update Radical to use babel-inline-replace to handle env variables.

This will allow us to cleanly use env variables without having to muck around with consuming apps UglifyJS settings. Console.image is pulled in for dev builds and shimmed in prod.

## Tests
<!-- Don't lie about this, Travis CI will call you out pretty fast if you do -->
- [ ] I added tests for changes I made
- [x] All tests are _definitely_ passing
