### PR TITLE
changes drawer target from width: 100% to display: block

### DIFF
--- a/app/styles/ember-radical/component-structures/_drawer.scss
+++ b/app/styles/ember-radical/component-structures/_drawer.scss
@@ -4,7 +4,7 @@
 
 .rad-drawer {
   .drawer-target {
-    width: 100%;
+    display: block;
   }
 
   .drawer-target {


### PR DESCRIPTION
to be more easily overwritten by default bootstrap classes

<!-- Please use this helpful template for filing Pull Requests. -->
<!-- If you haven't read the contribution guide, please do before submitting a PR; it will likely save a lot of time during the review process. -->

## Description
There is no `.w-auto` in bootstrap but there is a `.d-inline-block` so this would allow the drawer target to be displayed inline by just giving it a single bootstrap class rather than custom CSS. 

I honestly can't think of a situation where `display: block` won't render the same as `width: 100%`, but I could ***definitely*** be wrong here. 

These are the changes included:
Prefers using display property over width property for bootstrappy goodness
## Tests
NONE! Muahaha.
