### PR TITLE
fix close modal button/svg for edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## UNRELEASED
 
+## 1.8.3 (03-14-2018)
+### Fixed
+- Fixed an IE Edge-specific issue where close svg steals click event, preventing modal close.
+
 ## 1.8.2 (02-22-2018)
 ### Fixed
 - Fixed issue with updated label on `rad-tab.contetn` not being updated in `rad-tab` context.

--- a/app/styles/ember-radical/skeleton-theme/modules/_close.scss
+++ b/app/styles/ember-radical/skeleton-theme/modules/_close.scss
@@ -20,5 +20,6 @@ button.rad-button.close {
   // in line with fonts
   .rad-svg {
     bottom: 0;
+    pointer-events: none; // prevent svg from stealing click in IE Edge
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-radical",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "A set of lightweight, simple and fully accessible Ember DDAU components.",
   "homepage": "https://healthsparq.github.io/ember-radical",
   "keywords": [


### PR DESCRIPTION

## Description
The pull request addresses an IE Edge bug where an svg can absorb a click event without letting it bubble to the enclosing button. It fixes the problem using a common work-around (described here: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/10583086/) of adding "pointer-events: none;" to the svg element. The button now accepts click events again, and behavior for other browsers is unchanged.

These are the changes included:

- css change to _close.scss

## Tests
<!-- Don't lie about this, Travis CI will call you out pretty fast if you do -->
- [ ] I added tests for changes I made
- [ x ] All tests are _definitely_ passing
