### PR TITLE
fix: tablist accessibility

### DIFF
--- a/addon/components/rad-tabs.js
+++ b/addon/components/rad-tabs.js
@@ -337,12 +337,11 @@ export default Component.extend({
   // ---------------------------------------------------------------------------
   layout: hbs`
     {{! A list of buttons that are all automagically added to the tabList based on the number of rad-tabs.content components are nested inside the component. }}
-    <ul class="tab-list {{tabListClassNames}}{{if buttonStyle (concat ' ' buttonStyleClassNames)}}" role="tablist" data-test="tab-list">
+    <div class="tab-list {{tabListClassNames}}{{if buttonStyle (concat ' ' buttonStyleClassNames)}}" role="tablist" data-test="tab-list">
       {{#each tabList as |tab|}}
-        <li class={{tabClassNames}}
+        <div role="tab" class={{tabClassNames}}
           aria-hidden="{{if tab.hidden true false}}">
           {{#rad-button
-            ariaRole="tab"
             aria-controls=tab.elementId
             class=(concat 'tab' (if (eq tab.elementId activeId) ' active') ' ' tabButtonClassNames)
             link=true
@@ -353,9 +352,9 @@ export default Component.extend({
             taglabel=tab.taglabel}}
             {{tab.label}}
           {{/rad-button}}
-        </li>
+        </div>
       {{/each}}
-    </ul>
+    </div>
     <div class="content-container {{if card 'rad-card'}}">
       {{! Yield the rad-tabs/content component pre-bound with internal props }}
       {{yield

--- a/addon/components/rad-tabs.js
+++ b/addon/components/rad-tabs.js
@@ -339,7 +339,7 @@ export default Component.extend({
     {{! A list of buttons that are all automagically added to the tabList based on the number of rad-tabs.content components are nested inside the component. }}
     <div class="tab-list {{tabListClassNames}}{{if buttonStyle (concat ' ' buttonStyleClassNames)}}" role="tablist" data-test="tab-list">
       {{#each tabList as |tab|}}
-        <div role="tab" class={{tabClassNames}}
+        <div role="tab" data-test="tab" class={{tabClassNames}}
           aria-hidden="{{if tab.hidden true false}}">
           {{#rad-button
             aria-controls=tab.elementId

--- a/tests/integration/components/rad-tabs-test.js
+++ b/tests/integration/components/rad-tabs-test.js
@@ -393,24 +393,24 @@ module('Integration | Component | rad tabs', function(hooks) {
     {{/rad-tabs}}`)
 
     assert.ok(
-      find('[data-test="custom-classes-test"] ul').classList.contains(
+      find('[data-test="custom-classes-test"] div').classList.contains(
         'totally-rad-buttons',
       ),
-      'The custom buttonStyleClassNames should be applied to the ul',
+      'The custom buttonStyleClassNames should be applied to the div',
     )
 
     assert.ok(
-      find('[data-test="custom-classes-test"] ul').classList.contains(
+      find('[data-test="custom-classes-test"] div').classList.contains(
         'totally-effing-rad-tab-list',
       ),
-      'The custom tabListClassNames should be applied to the ul',
+      'The custom tabListClassNames should be applied to the div',
     )
 
     assert.ok(
-      find('[data-test="custom-classes-test"] li:first-child').classList.contains(
+      find('[data-test="custom-classes-test"] div div:first-child').classList.contains(
         'custom-tab-class',
       ),
-      'The custom tabClassNames should be applied to the tab item li elements',
+      'The custom tabClassNames should be applied to the tab item div elements',
     )
 
     assert.ok(

--- a/tests/integration/components/rad-tabs-test.js
+++ b/tests/integration/components/rad-tabs-test.js
@@ -393,21 +393,21 @@ module('Integration | Component | rad tabs', function(hooks) {
     {{/rad-tabs}}`)
 
     assert.ok(
-      find('[data-test="custom-classes-test"] div').classList.contains(
+      find('[data-test="tab-list"]').classList.contains(
         'totally-rad-buttons',
       ),
       'The custom buttonStyleClassNames should be applied to the div',
     )
 
     assert.ok(
-      find('[data-test="custom-classes-test"] div').classList.contains(
+      find('[data-test="tab-list"]').classList.contains(
         'totally-effing-rad-tab-list',
       ),
       'The custom tabListClassNames should be applied to the div',
     )
 
     assert.ok(
-      find('[data-test="custom-classes-test"] div div:first-child').classList.contains(
+      find('[data-test="tab"]').classList.contains(
         'custom-tab-class',
       ),
       'The custom tabClassNames should be applied to the tab item div elements',


### PR DESCRIPTION
#43  Description
Fixes 508 compliance issue where Lighthouse does not recognize a li element with a tablist role as being an actual list. Removed redundant ul and li elements and updated tab role.

## Tests
Updated tab tests for new elements and role.
